### PR TITLE
fix: remove em-dashes from blog posts, replace with contextual altern…

### DIFF
--- a/_archive/docs/posts/2025/ApiFirstStrongGrowth/index.md
+++ b/_archive/docs/posts/2025/ApiFirstStrongGrowth/index.md
@@ -13,12 +13,12 @@ tags:
 - strategy
 ---
 
-Recently, a discussion on the internal Slack at [Network to Code](https://networktocode.com) highlighted the "Amazon API Mandate" from 2002—a directive widely seen as transformative for Amazon. In the post (which can be found [here](https://nordicapis.com/the-bezos-api-mandate-amazons-manifesto-for-externalization/)), the core tenet is clear: **All teams will henceforth expose their data and functionality through service interfaces.** Upon rereading this mandate, I was immediately reminded of why I am such a strong believer in this strategy. Let's take a deeper dive. First, the mandate included the following requirements:
+Recently, a discussion on the internal Slack at [Network to Code](https://networktocode.com) highlighted the "Amazon API Mandate" from 2002, a directive widely seen as transformative for Amazon. In the post (which can be found [here](https://nordicapis.com/the-bezos-api-mandate-amazons-manifesto-for-externalization/)), the core tenet is clear: **All teams will henceforth expose their data and functionality through service interfaces.** Upon rereading this mandate, I was immediately reminded of why I am such a strong believer in this strategy. Let's take a deeper dive. First, the mandate included the following requirements:
 
 1. All teams will henceforth expose their data and functionality through service interfaces.
 2. Teams must communicate with each other through these interfaces.
 3. There will be no other form of interprocess communication allowed: no direct linking, no direct reads of another team’s data store, no shared-memory model, no back-doors whatsoever. The only communication allowed is via service interface calls over the network.
-4. It doesn’t matter what technology they use. HTTP, Corba, Pubsub, custom protocols — doesn’t matter.
+4. It doesn’t matter what technology they use. HTTP, Corba, Pubsub, custom protocols, doesn’t matter.
 5. All service interfaces, without exception, must be designed from the ground up to be externalizable. That is to say, the team must plan and design to be able to expose the interface to developers in the outside world. No exceptions.
 6. Anyone who doesn’t do this will be fired.
 7. Thank you; have a nice day!
@@ -37,7 +37,7 @@ With Nautobot Jobs, it is incredibly easy to start creating your own API service
 
 The primary reason aligns with the mandate described above: it is a tried-and-true method for enabling services to be consumed by other teams.
 
-On top of that, Nautobot provides all the mechanisms needed to secure and authenticate these API services. Instead of writing an API service from scratch—where you must handle authentication, permissions, logging, and infrastructure—**you can get started right away with your business logic**.
+On top of that, Nautobot provides all the mechanisms needed to secure and authenticate these API services. Instead of writing an API service from scratch (where you must handle authentication, permissions, logging, and infrastructure), **you can get started right away with your business logic**.
 
 ## Pub/Sub and Nautobot
 
@@ -53,7 +53,7 @@ Interestingly, I still see direct database access used for interprocess communic
 
 ## Summary
 
-When taking the next step in your automation journey—beyond the initial automation of read-only workflows with network devices—I believe you should look into delivering services via APIs and Pub/Sub systems. This is a natural progression and provides a strong foundation for building a modern network automation strategy.
+When taking the next step in your automation journey (beyond the initial automation of read-only workflows with network devices), I believe you should look into delivering services via APIs and Pub/Sub systems. This is a natural progression and provides a strong foundation for building a modern network automation strategy.
 
 I'm going to dive into a few specific examples in future posts to show how you can take advantage of these strategies.
 

--- a/_archive/docs/posts/2025/AutoCon4Day1/index.md
+++ b/_archive/docs/posts/2025/AutoCon4Day1/index.md
@@ -17,13 +17,13 @@ tags:
 - autocon
 ---
 
-[AutoCon4](https://networkautomation.forum/autocon4) and [NautoCon@AutoCon](https://go.networktocode.com/nautocon-autocon) are in the books. It was quite the day, and I have to say that it ranks among my best days of the year in Network Automation — right up there with being able to meet up with the Network to Code team earlier in the year. It was great to see many friends from across the community. Hopefully we’ll be able to keep the conversation going in Slack and maintain the momentum.
+[AutoCon4](https://networkautomation.forum/autocon4) and [NautoCon@AutoCon](https://go.networktocode.com/nautocon-autocon) are in the books. It was quite the day, and I have to say that it ranks among my best days of the year in Network Automation, right up there with being able to meet up with the Network to Code team earlier in the year. It was great to see many friends from across the community. Hopefully we’ll be able to keep the conversation going in Slack and maintain the momentum.
 
 <!-- more -->
 
 ## Personal Highlights
 
-I wasn’t able to attend every session due to some unavoidable day-to-day responsibilities, but I want to share a few of the highlights that stood out to me. If I missed anything, it’s not from a lack of effort — just time and priorities.
+I wasn’t able to attend every session due to some unavoidable day-to-day responsibilities, but I want to share a few of the highlights that stood out to me. If I missed anything, it’s not from a lack of effort, just time and priorities.
 
 ### NautoCon@AutoCon
 
@@ -31,23 +31,23 @@ This was the first time the Network to Code team has hosted this event, and it d
 
 ### The Hallway Track
 
-I’ll start with my favorite non-Nautobot part of the event — the hallway track. It was great to say hi to familiar faces and meet new ones. I reconnected with several people I rarely see in person, and for that I say **THANK YOU** — just for showing up and being among others.
+I’ll start with my favorite non-Nautobot part of the event: the hallway track. It was great to say hi to familiar faces and meet new ones. I reconnected with several people I rarely see in person, and for that I say **THANK YOU**, just for showing up and being among others.
 
-On the professional side, it was especially rewarding to meet customers of Network to Code who have entrusted us to deliver automation services and real value. It’s important to me that I keep driving the needle forward. If I ever reach a point where I’m not adding value — then it’s time for something different. Thankfully, that’s not the case right now. Things are very much moving forward.
+On the professional side, it was especially rewarding to meet customers of Network to Code who have entrusted us to deliver automation services and real value. It’s important to me that I keep driving the needle forward. If I ever reach a point where I’m not adding value, then it’s time for something different. Thankfully, that’s not the case right now. Things are very much moving forward.
 
 ## Presentations Attended
 
 There were multiple things happening for me during the event that kept me from attending every session, but I still caught several. Many were strong, and they sparked ideas I want to keep pursuing.
 
-One theme I’ll be writing about more in an upcoming post: there was a fair amount of CLI-driven automation — which is a great starting point — but the variety of automation types was even more encouraging. Across the talks I attended, I saw coverage across much of the device lifecycle. However, the early phases — Design and Pre-Deployment — were largely absent. I’d place the excellent talk by [Greg Botts](https://www.linkedin.com/in/greg-botts-728310138/) of Intel firmly in the Deployment phase since it focused on configuring hardware.
+One theme I’ll be writing about more in an upcoming post: there was a fair amount of CLI-driven automation (which is a great starting point), but the variety of automation types was even more encouraging. Across the talks I attended, I saw coverage across much of the device lifecycle. However, the early phases (Design and Pre-Deployment) were largely absent. I’d place the excellent talk by [Greg Botts](https://www.linkedin.com/in/greg-botts-728310138/) of Intel firmly in the Deployment phase since it focused on configuring hardware.
 
 ### Greg Botts — *Overhauling Data Center Network Automation: Intel’s Data-Centric Journey*
 
-This was a fantastic talk. It covered a lot — a real success story about putting data center automation in place with the right approach. They are well-positioned for the future, with everything needed to scale or handle break/fix replacements with ease. Once the video is published, this is one to prioritize.
+This was a fantastic talk. It covered a lot: a real success story about putting data center automation in place with the right approach. They are well-positioned for the future, with everything needed to scale or handle break/fix replacements with ease. Once the video is published, this is one to prioritize.
 
 ### Cat Gurinsky — *Lifecycle Automation: Troubleshooting, Upgrading & More*
 
-Cat walked through her journey in accelerating upgrades of data center gear. My biggest takeaway: **iteration matters**. This is a staple of successful Network Automation — you start with your experiences and build on them as new ones come.
+Cat walked through her journey in accelerating upgrades of data center gear. My biggest takeaway: **iteration matters**. This is a staple of successful Network Automation: you start with your experiences and build on them as new ones come.
 
 ### Chris Grundemann — *2025 State of Network Automation Survey Results*
 
@@ -55,7 +55,7 @@ I had to duck out a bit early for this one, but it’s a strong report and helps
 
 ## Summary
 
-Overall, this event remains my favorite non-internal one to attend. From meeting like-minded individuals to exploring the latest trends — it’s an incredible gathering of professionals in the Network Automation space.
+Overall, this event remains my favorite non-internal one to attend. From meeting like-minded individuals to exploring the latest trends, it’s an incredible gathering of professionals in the Network Automation space.
 
 What was your favorite part? Any other thoughts?
 

--- a/_archive/docs/posts/2025/Timezones/index.md
+++ b/_archive/docs/posts/2025/Timezones/index.md
@@ -12,7 +12,7 @@ tags:
   - network_design
 ---
 
-It’s been a while since my last post — life and work have both been full. Today, I’m diving into one of the most quietly critical aspects of network design: **time synchronization**. Specifically, how to design NTP within an enterprise network and how to think about time zones when correlating logs.
+It’s been a while since my last post, life and work have both been full. Today, I’m diving into one of the most quietly critical aspects of network design: **time synchronization**. Specifically, how to design NTP within an enterprise network and how to think about time zones when correlating logs.
 
 We'll look at two main topics in this post: designing NTP (Network Time Protocol) and managing time zone display in logs. 
 
@@ -20,7 +20,7 @@ We'll look at two main topics in this post: designing NTP (Network Time Protocol
 
 ## Network Time Protocol (NTP)
 
-Network Time Protocol (NTP) keeps device clocks synchronized — a small detail that can have big operational consequences. Accurate time is essential for correlating logs, troubleshooting issues, and maintaining consistency across systems. In enterprise environments, having a common time source is vital. Whether investigating a cyber incident or reviewing footage from security cameras, synchronized time keeps all data sources in lockstep.
+Network Time Protocol (NTP) keeps device clocks synchronized, a small detail that can have big operational consequences. Accurate time is essential for correlating logs, troubleshooting issues, and maintaining consistency across systems. In enterprise environments, having a common time source is vital. Whether investigating a cyber incident or reviewing footage from security cameras, synchronized time keeps all data sources in lockstep.
 
 ??? note "Precision Time Protocol"
     For most organizations, second-level precision is sufficient. However, environments requiring microsecond accuracy may use [Precision Time Protocol (PTP)](https://en.wikipedia.org/wiki/Precision_Time_Protocol). I haven’t personally needed that level of precision yet, but it’s worth exploring if your use case demands it.
@@ -29,9 +29,9 @@ Network Time Protocol (NTP) keeps device clocks synchronized — a small detail 
 
 The first design decision is whether your organization should maintain its own time source. Common dedicated sources include:
 
-- **Satellite clocks** — synchronized via GPS signals  
-- **Radio signals** — received from regional broadcast time services  
-- **Atomic clocks** — the reference source behind most public and private time systems  
+- **Satellite clocks**: synchronized via GPS signals  
+- **Radio signals**: received from regional broadcast time services  
+- **Atomic clocks**: the reference source behind most public and private time systems  
 
 ???+ note "Hosted Time Sources"
     If you’re hosting your own time source, **monitor it regularly** with your observability platform to ensure it’s receiving valid signals rather than relying on its internal oscillator. These devices periodically sync with their upstream references while serving NTP requests to downstream systems.
@@ -45,14 +45,14 @@ A good starting point is the [NTP Pool Project](https://www.ntppool.org/en/), wh
 
 ### Design Considerations
 
-Once your primary time source is established, ensure all systems retrieve time from reliable, redundant servers. In most environments, I recommend **a primary and secondary NTP source** — both enterprise-wide and within each site (data center, campus, or branch). Typically, a **Layer 3 device** such as a router or core switch provides local NTP services.
+Once your primary time source is established, ensure all systems retrieve time from reliable, redundant servers. In most environments, I recommend **a primary and secondary NTP source**, both enterprise-wide and within each site (data center, campus, or branch). Typically, a **Layer 3 device** such as a router or core switch provides local NTP services.
 
 ???+ note "Windows Time Service (W32Time)"
     Microsoft Windows systems don’t use NTP directly. They rely on the **Windows Time Service (W32Time)**, which synchronizes through Active Directory. Ensure your AD servers synchronize from the same authoritative NTP source as the rest of the environment.
 
 #### Data Center Time
 
-In larger data centers, consider deploying dedicated NTP servers that synchronize with your enterprise’s primary and secondary sources. These servers then provide time to all other equipment — not just network gear, but also hosts, VMs, and monitoring systems.  
+In larger data centers, consider deploying dedicated NTP servers that synchronize with your enterprise’s primary and secondary sources. These servers then provide time to all other equipment, not just network gear, but also hosts, VMs, and monitoring systems.  
 Virtual machines should derive time from their hypervisors, which in turn should sync with the NTP servers.
 
 #### Campus Designs
@@ -65,7 +65,7 @@ At branch sites, especially those with limited infrastructure, a single router c
 
 ## UTC Versus Local Time Zone
 
-When it comes to log timestamps, this decision is often cultural as much as technical. Ideally, all systems should record logs in **UTC**. However, for organizations operating entirely within one region, using **local time** can improve usability — as long as everyone understands the offset.  
+When it comes to log timestamps, this decision is often cultural as much as technical. Ideally, all systems should record logs in **UTC**. However, for organizations operating entirely within one region, using **local time** can improve usability, as long as everyone understands the offset.  
 For distributed teams across multiple time zones, UTC is almost always the better choice for correlation and analysis.
 
 ## EST vs. EDT — They’re the Same, Right?

--- a/content/posts/2025/ApiFirstStrongGrowth/index.md
+++ b/content/posts/2025/ApiFirstStrongGrowth/index.md
@@ -5,7 +5,7 @@ categories:
 - automation
 title: Services First - A Reminder of Strong Growth
 summary: >
-  This post explores why the "Amazon API Mandate" remains relevant for modern network automation. It highlights how adopting a "Services First" strategy—using APIs and Pub/Sub systems like Nautobot—can transform CLI-based workflows into scalable, robust services.
+  This post explores why the "Amazon API Mandate" remains relevant for modern network automation. It highlights how adopting a "Services First" strategy (using APIs and Pub/Sub systems like Nautobot) can transform CLI-based workflows into scalable, robust services.
 toc: true
 tags:
   - api
@@ -20,12 +20,12 @@ params:
   showComments: true
 ---
 
-Recently, a discussion on the internal Slack at [Network to Code](https://networktocode.com) highlighted the "Amazon API Mandate" from 2002—a directive widely seen as transformative for Amazon. In the post (which can be found [here](https://nordicapis.com/the-bezos-api-mandate-amazons-manifesto-for-externalization/)), the core tenet is clear: **All teams will henceforth expose their data and functionality through service interfaces.** Upon rereading this mandate, I was immediately reminded of why I am such a strong believer in this strategy. Let's take a deeper dive. First, the mandate included the following requirements:
+Recently, a discussion on the internal Slack at [Network to Code](https://networktocode.com) highlighted the "Amazon API Mandate" from 2002, a directive widely seen as transformative for Amazon. In the post (which can be found [here](https://nordicapis.com/the-bezos-api-mandate-amazons-manifesto-for-externalization/)), the core tenet is clear: **All teams will henceforth expose their data and functionality through service interfaces.** Upon rereading this mandate, I was immediately reminded of why I am such a strong believer in this strategy. Let's take a deeper dive. First, the mandate included the following requirements:
 
 1. All teams will henceforth expose their data and functionality through service interfaces.
 2. Teams must communicate with each other through these interfaces.
 3. There will be no other form of interprocess communication allowed: no direct linking, no direct reads of another team’s data store, no shared-memory model, no back-doors whatsoever. The only communication allowed is via service interface calls over the network.
-4. It doesn’t matter what technology they use. HTTP, Corba, Pubsub, custom protocols — doesn’t matter.
+4. It doesn’t matter what technology they use. HTTP, Corba, Pubsub, custom protocols, doesn’t matter.
 5. All service interfaces, without exception, must be designed from the ground up to be externalizable. That is to say, the team must plan and design to be able to expose the interface to developers in the outside world. No exceptions.
 6. Anyone who doesn’t do this will be fired.
 7. Thank you; have a nice day!
@@ -42,7 +42,7 @@ With Nautobot Jobs, it is incredibly easy to start creating your own API service
 
 The primary reason aligns with the mandate described above: it is a tried-and-true method for enabling services to be consumed by other teams.
 
-On top of that, Nautobot provides all the mechanisms needed to secure and authenticate these API services. Instead of writing an API service from scratch—where you must handle authentication, permissions, logging, and infrastructure—**you can get started right away with your business logic**.
+On top of that, Nautobot provides all the mechanisms needed to secure and authenticate these API services. Instead of writing an API service from scratch (where you must handle authentication, permissions, logging, and infrastructure), **you can get started right away with your business logic**.
 
 ## Pub/Sub and Nautobot
 
@@ -58,7 +58,7 @@ Interestingly, I still see direct database access used for interprocess communic
 
 ## Summary
 
-When taking the next step in your automation journey—beyond the initial automation of read-only workflows with network devices—I believe you should look into delivering services via APIs and Pub/Sub systems. This is a natural progression and provides a strong foundation for building a modern network automation strategy.
+When taking the next step in your automation journey (beyond the initial automation of read-only workflows with network devices), I believe you should look into delivering services via APIs and Pub/Sub systems. This is a natural progression and provides a strong foundation for building a modern network automation strategy.
 
 I'm going to dive into a few specific examples in future posts to show how you can take advantage of these strategies.
 

--- a/content/posts/2025/AutoCon4Day1/index.md
+++ b/content/posts/2025/AutoCon4Day1/index.md
@@ -18,13 +18,13 @@ params:
   showComments: true
 ---
 
-[AutoCon4](https://networkautomation.forum/autocon4) and [NautoCon@AutoCon](https://go.networktocode.com/nautocon-autocon) are in the books. It was quite the day, and I have to say that it ranks among my best days of the year in Network Automation — right up there with being able to meet up with the Network to Code team earlier in the year. It was great to see many friends from across the community. Hopefully we’ll be able to keep the conversation going in Slack and maintain the momentum.
+[AutoCon4](https://networkautomation.forum/autocon4) and [NautoCon@AutoCon](https://go.networktocode.com/nautocon-autocon) are in the books. It was quite the day, and I have to say that it ranks among my best days of the year in Network Automation, right up there with being able to meet up with the Network to Code team earlier in the year. It was great to see many friends from across the community. Hopefully we’ll be able to keep the conversation going in Slack and maintain the momentum.
 
 <!--more-->
 
 ## Personal Highlights
 
-I wasn’t able to attend every session due to some unavoidable day-to-day responsibilities, but I want to share a few of the highlights that stood out to me. If I missed anything, it’s not from a lack of effort — just time and priorities.
+I wasn’t able to attend every session due to some unavoidable day-to-day responsibilities, but I want to share a few of the highlights that stood out to me. If I missed anything, it’s not from a lack of effort, just time and priorities.
 
 ### NautoCon@AutoCon
 
@@ -32,23 +32,23 @@ This was the first time the Network to Code team has hosted this event, and it d
 
 ### The Hallway Track
 
-I’ll start with my favorite non-Nautobot part of the event — the hallway track. It was great to say hi to familiar faces and meet new ones. I reconnected with several people I rarely see in person, and for that I say **THANK YOU** — just for showing up and being among others.
+I’ll start with my favorite non-Nautobot part of the event: the hallway track. It was great to say hi to familiar faces and meet new ones. I reconnected with several people I rarely see in person, and for that I say **THANK YOU**, just for showing up and being among others.
 
-On the professional side, it was especially rewarding to meet customers of Network to Code who have entrusted us to deliver automation services and real value. It’s important to me that I keep driving the needle forward. If I ever reach a point where I’m not adding value — then it’s time for something different. Thankfully, that’s not the case right now. Things are very much moving forward.
+On the professional side, it was especially rewarding to meet customers of Network to Code who have entrusted us to deliver automation services and real value. It’s important to me that I keep driving the needle forward. If I ever reach a point where I’m not adding value, then it’s time for something different. Thankfully, that’s not the case right now. Things are very much moving forward.
 
 ## Presentations Attended
 
 There were multiple things happening for me during the event that kept me from attending every session, but I still caught several. Many were strong, and they sparked ideas I want to keep pursuing.
 
-One theme I’ll be writing about more in an upcoming post: there was a fair amount of CLI-driven automation — which is a great starting point — but the variety of automation types was even more encouraging. Across the talks I attended, I saw coverage across much of the device lifecycle. However, the early phases — Design and Pre-Deployment — were largely absent. I’d place the excellent talk by [Greg Botts](https://www.linkedin.com/in/greg-botts-728310138/) of Intel firmly in the Deployment phase since it focused on configuring hardware.
+One theme I’ll be writing about more in an upcoming post: there was a fair amount of CLI-driven automation (which is a great starting point), but the variety of automation types was even more encouraging. Across the talks I attended, I saw coverage across much of the device lifecycle. However, the early phases (Design and Pre-Deployment) were largely absent. I’d place the excellent talk by [Greg Botts](https://www.linkedin.com/in/greg-botts-728310138/) of Intel firmly in the Deployment phase since it focused on configuring hardware.
 
 ### Greg Botts — *Overhauling Data Center Network Automation: Intel’s Data-Centric Journey*
 
-This was a fantastic talk. It covered a lot — a real success story about putting data center automation in place with the right approach. They are well-positioned for the future, with everything needed to scale or handle break/fix replacements with ease. Once the video is published, this is one to prioritize.
+This was a fantastic talk. It covered a lot: a real success story about putting data center automation in place with the right approach. They are well-positioned for the future, with everything needed to scale or handle break/fix replacements with ease. Once the video is published, this is one to prioritize.
 
 ### Cat Gurinsky — *Lifecycle Automation: Troubleshooting, Upgrading & More*
 
-Cat walked through her journey in accelerating upgrades of data center gear. My biggest takeaway: **iteration matters**. This is a staple of successful Network Automation — you start with your experiences and build on them as new ones come.
+Cat walked through her journey in accelerating upgrades of data center gear. My biggest takeaway: **iteration matters**. This is a staple of successful Network Automation: you start with your experiences and build on them as new ones come.
 
 ### Chris Grundemann — *2025 State of Network Automation Survey Results*
 
@@ -56,7 +56,7 @@ I had to duck out a bit early for this one, but it’s a strong report and helps
 
 ## Summary
 
-Overall, this event remains my favorite non-internal one to attend. From meeting like-minded individuals to exploring the latest trends — it’s an incredible gathering of professionals in the Network Automation space.
+Overall, this event remains my favorite non-internal one to attend. From meeting like-minded individuals to exploring the latest trends, it’s an incredible gathering of professionals in the Network Automation space.
 
 What was your favorite part? Any other thoughts?
 

--- a/content/posts/2025/Timezones/index.md
+++ b/content/posts/2025/Timezones/index.md
@@ -13,7 +13,7 @@ params:
   showComments: true
 ---
 
-It’s been a while since my last post — life and work have both been full. Today, I’m diving into one of the most quietly critical aspects of network design: **time synchronization**. Specifically, how to design NTP within an enterprise network and how to think about time zones when correlating logs.
+It’s been a while since my last post, life and work have both been full. Today, I’m diving into one of the most quietly critical aspects of network design: **time synchronization**. Specifically, how to design NTP within an enterprise network and how to think about time zones when correlating logs.
 
 We'll look at two main topics in this post: designing NTP (Network Time Protocol) and managing time zone display in logs. 
 
@@ -21,7 +21,7 @@ We'll look at two main topics in this post: designing NTP (Network Time Protocol
 
 ## Network Time Protocol (NTP)
 
-Network Time Protocol (NTP) keeps device clocks synchronized — a small detail that can have big operational consequences. Accurate time is essential for correlating logs, troubleshooting issues, and maintaining consistency across systems. In enterprise environments, having a common time source is vital. Whether investigating a cyber incident or reviewing footage from security cameras, synchronized time keeps all data sources in lockstep.
+Network Time Protocol (NTP) keeps device clocks synchronized, a small detail that can have big operational consequences. Accurate time is essential for correlating logs, troubleshooting issues, and maintaining consistency across systems. In enterprise environments, having a common time source is vital. Whether investigating a cyber incident or reviewing footage from security cameras, synchronized time keeps all data sources in lockstep.
 
 > [!NOTE]- Precision Time Protocol
 > For most organizations, second-level precision is sufficient. However, environments requiring microsecond accuracy may use [Precision Time Protocol (PTP)](https://en.wikipedia.org/wiki/Precision_Time_Protocol). I haven’t personally needed that level of precision yet, but it’s worth exploring if your use case demands it.
@@ -30,9 +30,9 @@ Network Time Protocol (NTP) keeps device clocks synchronized — a small detail 
 
 The first design decision is whether your organization should maintain its own time source. Common dedicated sources include:
 
-- **Satellite clocks** — synchronized via GPS signals  
-- **Radio signals** — received from regional broadcast time services  
-- **Atomic clocks** — the reference source behind most public and private time systems  
+- **Satellite clocks**: synchronized via GPS signals  
+- **Radio signals**: received from regional broadcast time services  
+- **Atomic clocks**: the reference source behind most public and private time systems  
 
 > [!NOTE] Hosted Time Sources
 > If you’re hosting your own time source, **monitor it regularly** with your observability platform to ensure it’s receiving valid signals rather than relying on its internal oscillator. These devices periodically sync with their upstream references while serving NTP requests to downstream systems.
@@ -46,14 +46,14 @@ A good starting point is the [NTP Pool Project](https://www.ntppool.org/en/), wh
 
 ### Design Considerations
 
-Once your primary time source is established, ensure all systems retrieve time from reliable, redundant servers. In most environments, I recommend **a primary and secondary NTP source** — both enterprise-wide and within each site (data center, campus, or branch). Typically, a **Layer 3 device** such as a router or core switch provides local NTP services.
+Once your primary time source is established, ensure all systems retrieve time from reliable, redundant servers. In most environments, I recommend **a primary and secondary NTP source**, both enterprise-wide and within each site (data center, campus, or branch). Typically, a **Layer 3 device** such as a router or core switch provides local NTP services.
 
 > [!NOTE] Windows Time Service (W32Time)
 > Microsoft Windows systems don’t use NTP directly. They rely on the **Windows Time Service (W32Time)**, which synchronizes through Active Directory. Ensure your AD servers synchronize from the same authoritative NTP source as the rest of the environment.
 >
 #### Data Center Time
 
-In larger data centers, consider deploying dedicated NTP servers that synchronize with your enterprise’s primary and secondary sources. These servers then provide time to all other equipment — not just network gear, but also hosts, VMs, and monitoring systems.  
+In larger data centers, consider deploying dedicated NTP servers that synchronize with your enterprise’s primary and secondary sources. These servers then provide time to all other equipment, not just network gear, but also hosts, VMs, and monitoring systems.  
 Virtual machines should derive time from their hypervisors, which in turn should sync with the NTP servers.
 
 #### Campus Designs
@@ -66,7 +66,7 @@ At branch sites, especially those with limited infrastructure, a single router c
 
 ## UTC Versus Local Time Zone
 
-When it comes to log timestamps, this decision is often cultural as much as technical. Ideally, all systems should record logs in **UTC**. However, for organizations operating entirely within one region, using **local time** can improve usability — as long as everyone understands the offset.  
+When it comes to log timestamps, this decision is often cultural as much as technical. Ideally, all systems should record logs in **UTC**. However, for organizations operating entirely within one region, using **local time** can improve usability, as long as everyone understands the offset.  
 For distributed teams across multiple time zones, UTC is almost always the better choice for correlation and analysis.
 
 ## EST vs. EDT — They’re the Same, Right?

--- a/content/posts/2026/ai_initialization/index.md
+++ b/content/posts/2026/ai_initialization/index.md
@@ -6,7 +6,7 @@ categories:
 - ai
 title: "AI: Initializing"
 summary: >
-  I went from calling AI a 50/50 bet to burning through API credits in days. Here's what changed — from the Ralph Loop to OpenClaw to AI agent skills — and why I think we're at a pivotal point.
+  I went from calling AI a 50/50 bet to burning through API credits in days. Here's what changed, from the Ralph Loop to OpenClaw to AI agent skills, and why I think we're at a pivotal point.
 toc: true
 tags:
   - ai
@@ -20,7 +20,7 @@ params:
   showComments: true
 ---
 
-A year ago I called AI a 50/50 bet — half the time it worked, half the time I was re-checking and re-prompting. I was paying $20 a month to multiple providers just to keep an eye on things. AI was around, but it wasn't transforming how I worked. Not yet.
+A year ago I called AI a 50/50 bet. Half the time it worked, half the time I was re-checking and re-prompting. I was paying $20 a month to multiple providers just to keep an eye on things. AI was around, but it wasn't transforming how I worked. Not yet.
 
 Then a few weeks ago, something clicked. And I burned through my Anthropic and OpenAI credits faster than I thought possible.
 
@@ -31,7 +31,7 @@ It's early 2026, and many are pointing to the [Opus 4.6 Release](https://www.ant
 
 ## The Ralph Loop
 
-It started with the [Ralph Loop](https://ghuntley.com/loop/). The concept is straightforward — you give the AI a task, it builds, tests, and iterates in a loop until it's done. No hand-holding between steps. I tried it and blew through my credits in no time. Take a look at the spikes in usage: ![Codex Usage Dashboard](image.png). Those spikes were new features I was building for an app I thought I could ship. Except the paid app I already use came out with all of those features anyway. Which is great! One less thing for me to have to ask those around me to use.
+It started with the [Ralph Loop](https://ghuntley.com/loop/). The concept is straightforward: you give the AI a task, it builds, tests, and iterates in a loop until it's done. No hand-holding between steps. I tried it and blew through my credits in no time. Take a look at the spikes in usage: ![Codex Usage Dashboard](image.png). Those spikes were new features I was building for an app I thought I could ship. Except the paid app I already use came out with all of those features anyway. Which is great! One less thing for me to have to ask those around me to use.
 
 But that was just the start.
 
@@ -39,7 +39,7 @@ But that was just the start.
 
 For the past couple of weeks I have been using AI to help me out a little more at a time. Using Claude Code both in CLI and in the Desktop App, **exploring** what its capabilities are. And I have to say that it is pretty awesome.
 
-Then out of the blue for me — maybe not for others — up pops OpenClaw (Clawdbot -> Moltbot -> OpenClaw). My cousin put out an [article on his blog](https://aaronstuyvenberg.com/posts/clawd-bought-a-car) about using Clawdbot at the time to help him in the car buying experience. That's when it started to click about what the capabilities might be. Then I started to see what a few YouTube personalities were doing, and I said yes, I need to be getting in on this. So I spun up a VM on my home compute and I'm diving head first. The first week went well, and I'm looking forward to doing more.
+Then out of the blue for me (maybe not for others), up pops OpenClaw (Clawdbot -> Moltbot -> OpenClaw). My cousin put out an [article on his blog](https://aaronstuyvenberg.com/posts/clawd-bought-a-car) about using Clawdbot at the time to help him in the car buying experience. That's when it started to click about what the capabilities might be. Then I started to see what a few YouTube personalities were doing, and I said yes, I need to be getting in on this. So I spun up a VM on my home compute and I'm diving head first. The first week went well, and I'm looking forward to doing more.
 
 I'm also looking to dive into local models. I finally have my use case: a 24/7 available AI system that isn't too crazy and isn't too expensive. More on that in a future post.
 
@@ -47,25 +47,25 @@ There are multiple components that make up the sauce of OpenClaw and makes it po
 
 ### Memory
 
-One of the pieces that really sets OpenClaw apart is memory. Using simple Markdown files, the system remembers what you've talked about from chat to chat — your preferences, your decisions, your context. It's like having an assistant that actually knows you. Many LLMs are just starting to build this in natively, but OpenClaw has it working now.
+One of the pieces that really sets OpenClaw apart is memory. Using simple Markdown files, the system remembers what you've talked about from chat to chat: your preferences, your decisions, your context. It's like having an assistant that actually knows you. Many LLMs are just starting to build this in natively, but OpenClaw has it working now.
 
 ### Skills
 
-[AI Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) are reusable instructions — written in plain English — that teach AI agents how to use tools properly. It's the DRY (Don't Repeat Yourself) principle at its finest. And this isn't unique to OpenClaw — Claude, Gemini, Codex all have them. It is going to take some time to build out the skills needed to get these systems working in tip top shape, but the investment pays off quickly.
+[AI Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) are reusable instructions, written in plain English, that teach AI agents how to use tools properly. It's the DRY (Don't Repeat Yourself) principle at its finest. And this isn't unique to OpenClaw. Claude, Gemini, Codex all have them. It is going to take some time to build out the skills needed to get these systems working in tip top shape, but the investment pays off quickly.
 
 For example, instead of telling Claude how to format a commit message every single time, you write the skill once and it just knows. Instead of describing your project's testing conventions on every prompt, a skill file handles it. The AI agent systems already have a lot of capability and pattern matching built in. Skills just instruct the systems how to use what they have in their toolbox.
 
 ## Summary
 
-So, should I be looking at OpenClaw or Claude Code? I think **<u>both</u>**. Using AI systems that are directed by a human first and foremost makes sense. Having a person in the loop and making sure that things are being done and meet our standards — that is where we are at in Q1 of 2026 anyway in my mind.
+So, should I be looking at OpenClaw or Claude Code? I think **<u>both</u>**. Using AI systems that are directed by a human first and foremost makes sense. Having a person in the loop and making sure that things are being done and meet our standards. That is where we are at in Q1 of 2026 anyway in my mind.
 
-I went from paying $20 a month to barely touch AI, to burning through credits in days because I couldn't stop building. That shift happened fast, and I don't think I'm unique. We are hitting on something here. [Matt Shumer](https://x.com/mattshumer_/status/2021256989876109403) captures it well in his post — it's a terrific read, and I agree that we are at a pivotal point.
+I went from paying $20 a month to barely touch AI, to burning through credits in days because I couldn't stop building. That shift happened fast, and I don't think I'm unique. We are hitting on something here. [Matt Shumer](https://x.com/mattshumer_/status/2021256989876109403) captures it well in his post. It's a terrific read, and I agree that we are at a pivotal point.
 
 There will be a lot more exciting and challenging things happening. The best advice I can give is be willing to learn and **explore**. I'm looking forward to where the journey is taking me and there are still really good things to come.
 
 What are your thoughts? Comment below.
 
 > [!NOTE]- AI Editing Disclosure
-> This post was edited with the assistance of Claude Opus 4.6. The ideas and experiences are mine — the AI helped tighten the structure and clarity.
+> This post was edited with the assistance of Claude Opus 4.6. The ideas and experiences are mine. The AI helped tighten the structure and clarity.
 
 -Josh


### PR DESCRIPTION
…atives

Replaced em-dashes across 5 posts (content + archive copies) with commas, colons, parentheses, or periods based on context.

Preserved: signatures (— Josh) and section header separators.