### PR TITLE
chore: comment out Guides nav menu item

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -11,10 +11,10 @@
 # overridden by providing a weight value. The menu will then be
 # ordered by weight from lowest to highest.
 
-[[main]]
-  name = "Guides"
-  pageRef = "guides"
-  weight = 5
+# [[main]]
+#   name = "Guides"
+#   pageRef = "guides"
+#   weight = 5
 
 [[main]]
   name = "Blog"


### PR DESCRIPTION
Comments out the Guides link in the main nav while guides.josh-v.com is paused. One-line uncomment to restore.