### PR TITLE
fix: standardize RSS feed URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,11 @@ jobs:
             --minify \
             --baseURL "${{ vars.BASE_URL || 'https://josh-v.com/' }}"
 
+      - name: Copy RSS feed aliases
+        run: |
+          cp public/index.xml public/feed.xml
+          cp public/index.xml public/feed_rss_created.xml
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -18,11 +18,7 @@ googleAnalytics = "G-QCDLSTK9K6"
 
 [outputFormats.RSS]
   mediaType = "application/rss+xml"
-  baseName = "feed_rss_created"
-
-[outputFormats.RSS_UPDATED]
-  mediaType = "application/rss+xml"
-  baseName = "feed_rss_updated"
+  baseName = "index"
 
 [outputs]
-  home = ["HTML", "RSS", "RSS_UPDATED", "JSON"]
+  home = ["HTML", "RSS", "JSON"]


### PR DESCRIPTION
## What
Fixes #265 - RSS feed URLs returning 404. Feedly subscribers on `/index.xml` and `/feed.xml` were getting 404s.

## Changes
- Hugo RSS output now generates `/index.xml` (the standard path)
- CI copies it to `/feed.xml` and `/feed_rss_created.xml` for backward compatibility
- Removes unused `RSS_UPDATED` output format

## Result
All three feed URLs will work:
- `/index.xml` ✅ (standard)
- `/feed.xml` ✅ (Feedly)
- `/feed_rss_created.xml` ✅ (legacy)