### PR TITLE
fix: standardize RSS feed URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,11 +65,6 @@ jobs:
             --minify \
             --baseURL "${{ vars.BASE_URL || 'https://josh-v.com/' }}"
 
-      - name: Copy RSS feed aliases
-        run: |
-          cp public/index.xml public/feed.xml
-          cp public/index.xml public/feed_rss_created.xml
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,3 @@
+# RSS feed aliases - serve index.xml content at legacy feed URLs
+/feed.xml /index.xml 200
+/feed_rss_created.xml /index.xml 200


### PR DESCRIPTION
## What
Fixes #265 - RSS feed URLs returning 404. Feedly subscribers on `/index.xml` and `/feed.xml` were getting 404s.

## Changes
- Hugo RSS output now generates `/index.xml` (the standard path)
- Removed unused `RSS_UPDATED` output format
- Added Cloudflare Pages `_redirects` file to rewrite `/feed.xml` and `/feed_rss_created.xml` to `/index.xml`

## Result
All three feed URLs will work:
- `/index.xml` ✅ (standard, generated by Hugo)
- `/feed.xml` ✅ (Cloudflare rewrite)
- `/feed_rss_created.xml` ✅ (Cloudflare rewrite, legacy)