### PR TITLE
fix: add RSS icon to footer social links

### DIFF
--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -24,5 +24,6 @@ copyright = "Copyright © 2025 Josh VanDeraa. All rights reserved."
     { x-twitter = "https://twitter.com/vanderaaj" },
     { github = "https://github.com/jvanderaa"},
     { bluesky = "https://bsky.app/profile/joshv.me" },
-    { slack = "https://networktocode.slack.com/archives/D53RCGS3V"}
+    { slack = "https://networktocode.slack.com/archives/D53RCGS3V"},
+    { rss = "https://josh-v.com/index.xml" }
   ]


### PR DESCRIPTION
## What
Fixes #268 - Adds an RSS feed icon to the footer social links.

## Changes
- Added `rss` entry to author social links in `languages.en.toml`
- Points to `https://josh-v.com/index.xml`

## Result
RSS icon appears alongside LinkedIn, Mastodon, Bluesky, X, GitHub, and Slack in the footer.