### PR TITLE
feat: add email subscription form (placeholder - pending newsletter Worker)

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -56,3 +56,8 @@ enableQuicklink = true
 
 [taxonomy]
   showTermCount = true
+
+# Email subscriptions via Buttondown
+# Sign up at https://buttondown.com, then set your username below
+# [buttondown]
+#   username = "your-buttondown-username"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -57,7 +57,7 @@ enableQuicklink = true
 [taxonomy]
   showTermCount = true
 
-# Email subscriptions via Buttondown
-# Sign up at https://buttondown.com, then set your username below
-# [buttondown]
-#   username = "your-buttondown-username"
+# Email newsletter - Cloudflare Workers backend
+[newsletter]
+  enabled = true
+  endpoint = "https://blog-newsletter.bitter-frost-f4e5.workers.dev/subscribe"

--- a/content/subscribe/_index.md
+++ b/content/subscribe/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Subscribe"
+description: "Get new posts from Josh VanDeraa delivered to your inbox."
+layout: "simple"
+---
+
+Get notified when I publish new posts on network automation, AI, Python, and more.
+
+No spam. Just new content when it's ready. Unsubscribe any time.
+
+{{< subscribe >}}

--- a/layouts/_partials/extend-footer.html
+++ b/layouts/_partials/extend-footer.html
@@ -1,16 +1,13 @@
-{{/* Email subscribe form - powered by Buttondown */}}
-{{/* Replace YOUR_USERNAME below with your Buttondown username after signing up */}}
-{{ if .Site.Params.buttondown.username }}
+{{/* Email subscribe form - powered by Cloudflare Workers */}}
+{{ with .Site.Params.newsletter }}
+{{ if .enabled }}
 <div class="mt-8 border-t border-neutral-200 pt-8 dark:border-neutral-600 print:hidden">
   <div class="mx-auto max-w-md text-center">
     <p class="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-300">
       Get new posts by email
     </p>
     <form
-      action="https://buttondown.com/api/emails/embed-subscribe/{{ .Site.Params.buttondown.username }}"
-      method="post"
-      target="popupwindow"
-      onsubmit="window.open('https://buttondown.com/{{ .Site.Params.buttondown.username }}', 'popupwindow')"
+      id="footer-subscribe-form"
       class="flex flex-col gap-2 sm:flex-row sm:justify-center"
     >
       <input
@@ -20,7 +17,6 @@
         required
         class="rounded-md border border-neutral-300 bg-neutral px-3 py-2 text-sm text-neutral-900 placeholder-neutral-400 focus:border-primary-500 focus:outline-none dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:placeholder-neutral-500"
       />
-      <input type="hidden" value="1" name="embed" />
       <button
         type="submit"
         class="rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 focus:outline-none"
@@ -28,9 +24,48 @@
         Subscribe
       </button>
     </form>
-    <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+    <p id="footer-subscribe-msg" class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
       No spam. Unsubscribe any time.
     </p>
   </div>
 </div>
+<script>
+(function() {
+  var form = document.getElementById('footer-subscribe-form');
+  var msg = document.getElementById('footer-subscribe-msg');
+  if (!form) return;
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var email = form.querySelector('input[name="email"]').value;
+    var btn = form.querySelector('button');
+    btn.disabled = true;
+    btn.textContent = 'Subscribing...';
+    fetch('{{ .endpoint }}', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email })
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.error) {
+        msg.textContent = data.error;
+        msg.style.color = '#ef4444';
+      } else {
+        msg.textContent = data.message || 'Check your email to confirm!';
+        msg.style.color = '#22c55e';
+        form.reset();
+      }
+      btn.disabled = false;
+      btn.textContent = 'Subscribe';
+    })
+    .catch(function() {
+      msg.textContent = 'Something went wrong. Please try again.';
+      msg.style.color = '#ef4444';
+      btn.disabled = false;
+      btn.textContent = 'Subscribe';
+    });
+  });
+})();
+</script>
+{{ end }}
 {{ end }}

--- a/layouts/_partials/extend-footer.html
+++ b/layouts/_partials/extend-footer.html
@@ -1,0 +1,36 @@
+{{/* Email subscribe form - powered by Buttondown */}}
+{{/* Replace YOUR_USERNAME below with your Buttondown username after signing up */}}
+{{ if .Site.Params.buttondown.username }}
+<div class="mt-8 border-t border-neutral-200 pt-8 dark:border-neutral-600 print:hidden">
+  <div class="mx-auto max-w-md text-center">
+    <p class="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-300">
+      Get new posts by email
+    </p>
+    <form
+      action="https://buttondown.com/api/emails/embed-subscribe/{{ .Site.Params.buttondown.username }}"
+      method="post"
+      target="popupwindow"
+      onsubmit="window.open('https://buttondown.com/{{ .Site.Params.buttondown.username }}', 'popupwindow')"
+      class="flex flex-col gap-2 sm:flex-row sm:justify-center"
+    >
+      <input
+        type="email"
+        name="email"
+        placeholder="you@example.com"
+        required
+        class="rounded-md border border-neutral-300 bg-neutral px-3 py-2 text-sm text-neutral-900 placeholder-neutral-400 focus:border-primary-500 focus:outline-none dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:placeholder-neutral-500"
+      />
+      <input type="hidden" value="1" name="embed" />
+      <button
+        type="submit"
+        class="rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 focus:outline-none"
+      >
+        Subscribe
+      </button>
+    </form>
+    <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+      No spam. Unsubscribe any time.
+    </p>
+  </div>
+</div>
+{{ end }}

--- a/layouts/shortcodes/subscribe.html
+++ b/layouts/shortcodes/subscribe.html
@@ -1,10 +1,8 @@
-{{/* Buttondown subscribe form shortcode */}}
-{{ if .Site.Params.buttondown.username }}
+{{/* Newsletter subscribe form shortcode - powered by Cloudflare Workers */}}
+{{ with .Site.Params.newsletter }}
+{{ if .enabled }}
 <form
-  action="https://buttondown.com/api/emails/embed-subscribe/{{ .Site.Params.buttondown.username }}"
-  method="post"
-  target="popupwindow"
-  onsubmit="window.open('https://buttondown.com/{{ .Site.Params.buttondown.username }}', 'popupwindow')"
+  id="page-subscribe-form"
   class="not-prose flex flex-col gap-3 sm:flex-row sm:items-center"
 >
   <input
@@ -14,7 +12,6 @@
     required
     class="flex-1 rounded-md border border-neutral-300 bg-neutral px-3 py-2 text-sm text-neutral-900 placeholder-neutral-400 focus:border-primary-500 focus:outline-none dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:placeholder-neutral-500"
   />
-  <input type="hidden" value="1" name="embed" />
   <button
     type="submit"
     class="rounded-md bg-primary-600 px-5 py-2 text-sm font-semibold text-white hover:bg-primary-700 focus:outline-none"
@@ -22,7 +19,46 @@
     Subscribe
   </button>
 </form>
-<p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">No spam. Unsubscribe any time.</p>
+<p id="page-subscribe-msg" class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">No spam. Unsubscribe any time.</p>
+<script>
+(function() {
+  var form = document.getElementById('page-subscribe-form');
+  var msg = document.getElementById('page-subscribe-msg');
+  if (!form) return;
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var email = form.querySelector('input[name="email"]').value;
+    var btn = form.querySelector('button');
+    btn.disabled = true;
+    btn.textContent = 'Subscribing...';
+    fetch('{{ .endpoint }}', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email })
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.error) {
+        msg.textContent = data.error;
+        msg.style.color = '#ef4444';
+      } else {
+        msg.textContent = data.message || 'Check your email to confirm!';
+        msg.style.color = '#22c55e';
+        form.reset();
+      }
+      btn.disabled = false;
+      btn.textContent = 'Subscribe';
+    })
+    .catch(function() {
+      msg.textContent = 'Something went wrong. Please try again.';
+      msg.style.color = '#ef4444';
+      btn.disabled = false;
+      btn.textContent = 'Subscribe';
+    });
+  });
+})();
+</script>
 {{ else }}
-<!-- Buttondown not configured: set [buttondown] username in params.toml -->
+<!-- Newsletter not configured: set [newsletter] in params.toml -->
+{{ end }}
 {{ end }}

--- a/layouts/shortcodes/subscribe.html
+++ b/layouts/shortcodes/subscribe.html
@@ -1,0 +1,28 @@
+{{/* Buttondown subscribe form shortcode */}}
+{{ if .Site.Params.buttondown.username }}
+<form
+  action="https://buttondown.com/api/emails/embed-subscribe/{{ .Site.Params.buttondown.username }}"
+  method="post"
+  target="popupwindow"
+  onsubmit="window.open('https://buttondown.com/{{ .Site.Params.buttondown.username }}', 'popupwindow')"
+  class="not-prose flex flex-col gap-3 sm:flex-row sm:items-center"
+>
+  <input
+    type="email"
+    name="email"
+    placeholder="you@example.com"
+    required
+    class="flex-1 rounded-md border border-neutral-300 bg-neutral px-3 py-2 text-sm text-neutral-900 placeholder-neutral-400 focus:border-primary-500 focus:outline-none dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral dark:placeholder-neutral-500"
+  />
+  <input type="hidden" value="1" name="embed" />
+  <button
+    type="submit"
+    class="rounded-md bg-primary-600 px-5 py-2 text-sm font-semibold text-white hover:bg-primary-700 focus:outline-none"
+  >
+    Subscribe
+  </button>
+</form>
+<p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">No spam. Unsubscribe any time.</p>
+{{ else }}
+<!-- Buttondown not configured: set [buttondown] username in params.toml -->
+{{ end }}


### PR DESCRIPTION
## What this adds

Subscribe form scaffolding for the blog - footer form and /subscribe page. The form HTML is in place but the backend is being built as a separate Cloudflare Workers project.

**This PR should be merged after the Worker is deployed** and the form action URL is updated (tracked in US-006 of the newsletter PRD).

---

## Backend Plan

The email subscription backend will be a **self-hosted Cloudflare Worker** using:
- **Cloudflare Workers** - subscribe endpoint + cron trigger
- **Cloudflare D1** - subscriber database (SQLite, free tier)
- **Resend** - transactional email API (free up to 3,000/month)

PRD saved at: `.agents/tasks/prd-blog-newsletter.json`

**Estimated cost: $0/month** at current subscriber scale.

---

## Files in this PR
- `layouts/_partials/extend-footer.html` - subscribe form in site footer (Congo extension hook)
- `layouts/shortcodes/subscribe.html` - reusable shortcode for /subscribe page
- `content/subscribe/_index.md` - dedicated subscribe landing page at /subscribe
- `config/_default/params.toml` - commented [buttondown] config block (will be replaced with Worker URL config)

---

## TODO before merging
- [x] Worker deployed to Cloudflare
- [ ] Update form action URL to point at Worker POST /subscribe endpoint
- [ ] Remove Buttondown config from params.toml, replace with worker_url param