### PR TITLE
chore: update Hugo theme modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.152.2
+      HUGO_VERSION: 0.164.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.152.2
+      HUGO_VERSION: 0.164.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+hugo extended_0.164.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/jvanderaa/jvanderaa.github.io
 go 1.25.5
 
 require (
-	github.com/KKKZOZ/hugo-admonitions v0.12.0 // indirect
-	github.com/jpanther/congo/v2 v2.13.0 // indirect
+	github.com/KKKZOZ/hugo-admonitions v0.12.1 // indirect
+	github.com/jpanther/congo/v2 v2.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/KKKZOZ/hugo-admonitions v0.12.0 h1:x74ZrNUCrySH5JHPO2qGx+b1Mz8r+F1rBlH9qM833io=
 github.com/KKKZOZ/hugo-admonitions v0.12.0/go.mod h1:4PsJAsqo3mS3VzAtDLa8k0ds+CJQUWZhAo9kLi1NRlM=
+github.com/KKKZOZ/hugo-admonitions v0.12.1 h1:SMpeJ4/0VUXwpy1bgmyigNrXTPmAFrO28/+jQ4+dDpA=
+github.com/KKKZOZ/hugo-admonitions v0.12.1/go.mod h1:4PsJAsqo3mS3VzAtDLa8k0ds+CJQUWZhAo9kLi1NRlM=
 github.com/jpanther/congo/v2 v2.13.0 h1:kI73uW3e9aiPuN9so6lzZg+iEW8UVTmIPCNZvJ1cijI=
 github.com/jpanther/congo/v2 v2.13.0/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=
+github.com/jpanther/congo/v2 v2.14.0 h1:qzd7vjZpSPJkyX27Yl3KT87jvYs2aghIHCHXPSmJtXo=
+github.com/jpanther/congo/v2 v2.14.0/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=


### PR DESCRIPTION
Updates the Hugo theme modules to their latest releases, plus the Hugo version bump they require.

### Module updates
- `github.com/jpanther/congo/v2`: v2.13.0 → v2.14.0
- `github.com/KKKZOZ/hugo-admonitions`: v0.12.0 → v0.12.1

### Required Hugo bump (coupled)
Congo v2.14.0 requires **Hugo >= 0.158.0** (its `baseof.html` now uses `site.Language.Locale`, absent in 0.152.2). Without this, the build fails with `can't evaluate field Locale in type *langs.Language`. This PR therefore also:
- Bumps `HUGO_VERSION` 0.152.2 → 0.164.0 in `deploy.yml` and `test-build.yml`
- Adds `.tool-versions` pinning `hugo extended_0.164.0` for the Cloudflare Pages build

Verified locally with a clean `hugo --gc --minify` build on Hugo v0.164.0.

> [!IMPORTANT]
> If Cloudflare Pages has a `HUGO_VERSION` environment variable set in the dashboard, it will override `.tool-versions`. That dashboard value must be bumped to `0.164.0` (or removed) or the Cloudflare build will still fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)